### PR TITLE
Make client terminate gracefully

### DIFF
--- a/include/LoopClosing.h
+++ b/include/LoopClosing.h
@@ -47,7 +47,7 @@ public:
 
     typedef pair<set<KeyFrame*>,int> ConsistentGroup;
     typedef map<KeyFrame*,g2o::Sim3,std::less<KeyFrame*>,
-        Eigen::aligned_allocator<std::pair<const KeyFrame*, g2o::Sim3> > > KeyFrameAndPose;
+        Eigen::aligned_allocator<std::pair<KeyFrame* const , g2o::Sim3> > > KeyFrameAndPose;
 
 public:
 

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -2321,12 +2321,17 @@ void Tracking::tcp_receive(moodycamel::ConcurrentQueue<std::string>* messageQueu
 
 // Edge-SLAM: added destructor to destroy all connections on object termination
 Tracking::~Tracking(){
-    keyframe_socket->~TcpSocket();
-    frame_socket->~TcpSocket();
+    keyframe_socket->setAlive(false);
+    frame_socket->setAlive(false);
     map_socket->~TcpSocket();
+
     // This is just a dummy enqueue to unblock the wait_dequeue function in tcp_send()
     keyframe_queue.enqueue("exit");
     frame_queue.enqueue("exit");
+
+    keyframe_thread->join();
+    frame_thread->join();
+    map_thread->join();
 }
 
 } //namespace ORB_SLAM


### PR DESCRIPTION
Currently, when the client is terminated on `SIGINT`, `Tracking::~Tracking()` shows unsafe behavior:

https://github.com/droneslab/edgeslam/blob/d5489799297019af847d51c625a6794fb43bf045/src/Tracking.cc#L2323-L2330

The sockets are destroyed, then "exit" messages are sent through the queue to signal `keyframe_thread` and `frame_thread` to terminate.

After the two threads are un-blocked in `tcp_send()`, they will then call `TcpSocket::checkAlive()` before terminating. This is unsafe since the sockets might have already been destroyed (it causes a segfault on my machine):

https://github.com/droneslab/edgeslam/blob/d5489799297019af847d51c625a6794fb43bf045/src/Tracking.cc#L2257

This pull request fixes this issue.